### PR TITLE
automate building on Un*x systems

### DIFF
--- a/release.cmd
+++ b/release.cmd
@@ -6,4 +6,4 @@ sed -i -E "s/version>.+?</version>%VER%</; s/download\/.+?\/lull-the-tabs-.+?\.x
 
 set XPI=lull-the-tabs-%VER%.xpi
 if exist %XPI% del %XPI%
-zip -r9q %XPI% * -x .git/* .gitignore update.xml LICENSE README.md *.cmd *.xpi *.exe
+zip -r9q %XPI% * -x .git/* .gitignore update.xml LICENSE README.md *.cmd *.xpi *.exe *.sh

--- a/release.sh
+++ b/release.sh
@@ -7,7 +7,7 @@ zip_with_p7z() {
 	list_files | xargs -0 $Zip_Archiver a . -so -tzip > $XPI -mmt=1 -mx=9
 }
 zip_with_InfoZip() {
-    list_files | xargs -0 zip -r9q - > $XPI
+	list_files | xargs -0 zip -r9q - > $XPI
 }
 
 VER=1.5.2

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+list_files() {
+	find -maxdepth 1 -mindepth 1 -not -iregex '^./\(.git\|.gitignore\|update.xml\|LICENSE\|README.md\|.*\.\(cmd\|xpi\|exe\|sh\)$\)' -print0
+}
+zip_with_p7z() {
+	list_files | xargs -0 $Zip_Archiver a . -so -tzip > $XPI -mmt=1 -mx=9
+}
+zip_with_InfoZip() {
+    list_files | xargs -0 zip -r9q - > $XPI
+}
+
+VER=1.5.2
+sed -i "s/version>.+?</version>$VER</" install.rdf
+sed -i -E "s/version>.+?</version>$VER</; s/download\/.+?\/lull-the-tabs-.+?\.xpi/download\/$VER\/lull-the-tabs-$VER\.xpi/" update.xml
+
+XPI=lull-the-tabs-$VER.xpi
+
+Zip_Archiver=$(which 7za 7z zip | head -1 | rev | cut -f1 -d/ | rev)
+
+case $Zip_Archiver in
+    7za|7z) zip_with_p7z
+;;
+    zip) zip_with_InfoZip
+;;
+    ""|*) echo "Error: You must install 7za, 7z, or zip (infozip)."; exit 1
+;;
+esac


### PR DESCRIPTION
Hello.

I made this PR because I feel that the `release.cmd` should file be ported to Un*x shells, so as to make it easier for any Un*x users who change the code to test their changes. Since there's no guarantee that a user will have a fixed set of installed programs, I have written a shell script that supports both Posix-7zip (the `7z`, and `7za` executables), and the `zip` program from the `infozip` package. The script will automatically pick whichever one it finds first.

Thanks for all you do.

PS: This is my first pull request I've ever made on any project, so if I've done anything weird and/or stupid, please let me know.